### PR TITLE
temp fix for E: Version '15.0' for 'libedgetpu1-max' was not found

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -27,7 +27,7 @@ RUN apt-get -qq update \
     && echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list \
     && echo "libedgetpu1-max libedgetpu/accepted-eula select true" | debconf-set-selections \
     && apt-get -qq update && apt-get -qq install --no-install-recommends -y \
-        libedgetpu1-max=15.0 \
+        libedgetpu1-max=16.0 \
     && rm -rf /var/lib/apt/lists/* /wheels \
     && (apt-get autoremove -y; apt-get autoclean -y)
 


### PR DESCRIPTION
E: Version '15.0' for 'libedgetpu1-max' was not found
F: Version '16.0' was found

NB. Coral has NOT arrived as yet, so unsure if this is a breaking version change.